### PR TITLE
Fix class name imports

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -13,6 +13,7 @@ setWcStorybookHelpersConfig({ typeRef: 'expandedType' });
 setCustomElementsManifest(customElements);
 setWcDoxConfig(manifest, {
   imports: {
+    langOnPreTag: true,
     imports: [
       {
         label: 'HTML',

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -11,7 +11,30 @@ import type { Preview } from '@storybook/web-components';
 
 setWcStorybookHelpersConfig({ typeRef: 'expandedType' });
 setCustomElementsManifest(customElements);
-setWcDoxConfig(manifest);
+setWcDoxConfig(manifest, {
+  imports: {
+    imports: [
+      {
+        label: 'HTML',
+        lang: 'html',
+        importTemplate: (tagName, className) =>
+          `<script type="module" src="https://cdn.jsdelivr.net/npm/my-library/dist/${tagName}/${className}.js"></script>`,
+      },
+      {
+        label: 'NPM',
+        lang: 'js',
+        importTemplate: (tagName, className) =>
+          `import 'my-library/dist/${tagName}/${className}.js';`,
+      },
+      {
+        label: 'React',
+        lang: 'js',
+        importTemplate: tagName =>
+          `import 'my-library/react/${tagName}/index.js';`,
+      },
+    ],
+  },
+});
 
 const preview: Preview = {
   parameters: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.0
+
+- Added `langOnPreTag` setting to `imports` to set the language class on the `pre` element instead of the `code` element
+- Fixed parameters for `importTemplate` to use content from the CEM rather than the component properties
+
 ## 1.0.4
 
 - Fixed logic for hiding components when there is no content

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ type ImportsElementConfig = {
   copiedIcon?: string;
   /** The label used when the content is copied */
   copiedLabel?: string;
+  /** Sets the language class on `pre` tag instead of `code` tag */
+  langOnPreTag?: boolean;
   /** The list of import options */
   imports?: ImportConfig[];
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-dox",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "A web component API documentation generator",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/components/imports/imports.ts
+++ b/src/components/imports/imports.ts
@@ -2,11 +2,13 @@ import { LitElement } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import styles from './imports.styles.js';
 import { ImportsElementConfig } from '../../configs/types.js';
-import { config } from '../../configs/index.js';
+import { config, manifest } from '../../configs/index.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 import { markdownToHtml } from '../../utils/markdown.js';
 import { html, unsafeStatic } from 'lit/static-html.js';
+import * as cem from 'custom-elements-manifest/schema';
+import { getComponent } from '../../utils/cem-tools.js';
 
 let importId = 0;
 
@@ -26,15 +28,6 @@ export class WcImports extends LitElement {
     return this;
   }
 
-  override connectedCallback() {
-    super.connectedCallback();
-    importId++;
-
-    if (config.hideOnEmpty && !this.config?.imports?.length) {
-      this.hidden = true;
-    }
-  }
-
   @property()
   tag?: string;
 
@@ -50,9 +43,22 @@ export class WcImports extends LitElement {
   @state()
   copied = false;
 
+  @state()
+  component?: cem.CustomElement;
+
   public constructor() {
     super();
     this.config = config.imports;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.component = getComponent(manifest, this.componentClass, this.tag);
+    importId++;
+
+    if (config.hideOnEmpty && !this.config?.imports?.length) {
+      this.hidden = true;
+    }
   }
 
   private handleTabClick(i: number) {
@@ -108,7 +114,7 @@ export class WcImports extends LitElement {
 
         ${this.config?.imports?.map((x, i) => {
           const content =
-            x.importTemplate?.(this.tag ?? '', this.componentClass ?? '') || '';
+            x.importTemplate?.(this.component?.tagName ?? '', this.component?.name ?? '') || '';
           return html`<div
             id="tabpanel-${importId}${i}"
             class="tabpanel"

--- a/src/components/imports/imports.ts
+++ b/src/components/imports/imports.ts
@@ -115,6 +115,7 @@ export class WcImports extends LitElement {
         ${this.config?.imports?.map((x, i) => {
           const content =
             x.importTemplate?.(this.component?.tagName ?? '', this.component?.name ?? '') || '';
+          const lang = `language-${x.lang}`;
           return html`<div
             id="tabpanel-${importId}${i}"
             class="tabpanel"
@@ -122,8 +123,8 @@ export class WcImports extends LitElement {
             aria-labelledby="tab-${importId}-${i}"
             ?hidden="${this.selectedImport !== i}"
           >
-            <pre>
-              <code class="language-${x.lang}">${content}</code>
+            <pre class="${this.config?.langOnPreTag ? lang : ''}">
+              <code class="${!this.config?.langOnPreTag ? lang : ''}">${content}</code>
             </pre>
             <button
               class="copy-button"

--- a/src/configs/types.ts
+++ b/src/configs/types.ts
@@ -55,6 +55,8 @@ export type ImportsElementConfig = {
   copiedIcon?: string;
   /** The label used when the content is copied */
   copiedLabel?: string;
+  /** Sets the language class on `pre` tag instead of `code` tag */
+  langOnPreTag?: boolean;
   /** The list of import options */
   imports?: ImportConfig[];
 };


### PR DESCRIPTION
- Added `langOnPreTag` setting to `imports` to set the language class on the `pre` element instead of the `code` element (adds feature for #5)
- Fixed parameters for `importTemplate` to use content from the CEM rather than the component properties (fixes #4)