### PR TITLE
minor doc fix: escape / in </script>

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ imports: {
       label: 'HTML',
       lang: 'html',
       importTemplate: (tagName, className) =>
-        `<script type="module" src="https://cdn.jsdelivr.net/npm/my-library/dist/${tagName}/${className}.js"></script>`,
+        `<script type="module" src="https://cdn.jsdelivr.net/npm/my-library/dist/${tagName}/${className}.js"><\/script>`,
     },
     {
       label: 'NPM',


### PR DESCRIPTION
Was getting a compile error, escaping the script tag ensured this didn't happen. Could be build environment but an easy fix that won't hurt other builds.