### PR TITLE
Methods doc wrong"

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ methods: {
   heading: 'Methods',
   headingId: 'methods',
   skipLinkLabel: 'Skip to methods',
-  description: 'The following CSS parts are available:',
+  description: 'The following Methods are available:',
   headings: ['Name', 'Description', 'Deprecated'],
   rowTemplate: method =>
     `<tr>

--- a/src/configs/default-values.ts
+++ b/src/configs/default-values.ts
@@ -76,7 +76,7 @@ export const defaultDoxConfig: DoxConfig = {
     heading: 'Methods',
     headingId: 'methods',
     skipLinkLabel: 'Skip to methods',
-    description: 'The following CSS parts are available:',
+    description: 'The following Methods are available:',
     headings: ['Name', 'Description', 'Deprecated'],
     rowTemplate: method =>
       `<tr>


### PR DESCRIPTION
Statement for Methods is 'The following CSS parts...' should be `Methods` and not `CSS parts`